### PR TITLE
space is no longer needed before {r}..{/r:..}

### DIFF
--- a/markdown-rubytext.php
+++ b/markdown-rubytext.php
@@ -20,7 +20,7 @@ class MarkdownRubyTextPlugin extends Plugin
         $markdown->addInlineType('{', 'RubyText');
         // Add function to handle this
         $markdown->inlineRubyText = function($excerpt) {
-            if (preg_match('/\{r}(\S+){\/r:(\S+)}/', $excerpt['text'], $matches))
+            if (preg_match('/\{r}([^\s{]+){\/r:([^\s}]+)}/', $excerpt['text'], $matches))
             {
                 return
                 array(


### PR DESCRIPTION
Adjusted the regular expression to allow {r}..{/r:..}{r}..{/r:..} without whitespace between them.