### PR TITLE
Provide [ruby] shortcode

### DIFF
--- a/markdown-rubytext.php
+++ b/markdown-rubytext.php
@@ -1,7 +1,9 @@
 <?php
 namespace Grav\Plugin;
+
 use \Grav\Common\Plugin;
-use RocketTheme\Toolbox\Event\Event;
+
+
 class MarkdownRubyTextPlugin extends Plugin
 {
     /**
@@ -10,45 +12,24 @@ class MarkdownRubyTextPlugin extends Plugin
     public static function getSubscribedEvents()
     {
         return [
-            'onMarkdownInitialized' => ['onMarkdownInitialized', 0],
+            'onShortcodeHandlers' => ['onShortcodeHandlers', 0],
+            'onTwigTemplatePaths' => ['onTwigTemplatePaths', 0],
         ];
     }
-    public function onMarkdownInitialized(Event $event)
+
+    /**
+     * Add current directory to twig lookup paths.
+     */
+    public function onTwigTemplatePaths()
     {
-        $markdown = $event['markdown'];
-        // Initialize Text example
-        $markdown->addInlineType('{', 'RubyText');
-        // Add function to handle this
-        $markdown->inlineRubyText = function($excerpt) {
-            if (preg_match('/\{r}([^\s{]+){\/r:([^\s}]+)}/', $excerpt['text'], $matches))
-            {
-                return
-                array(
-                  'extent' => strlen($matches[0]),
-                  'element' => array(
-                    'name' => 'ruby',
-                    'handler' => 'elements',
-                    'text' => array(
-                        array(
-                            'name' => 'rb',
-                            'text' => $matches[1],
-                            ),
-                        array(
-                            'name' => 'rp',
-                            'text' => '（',
-                            ),
-                        array(    
-                            'name' => 'rt',
-                            'text' => $matches[2],
-                            ),
-                        array(
-                            'name' => 'rp',
-                            'text' => '）',
-                            )
-                        )
-                    )
-                );
-            }
-        };
+        $this->grav['twig']->twig_paths[] = __DIR__ . '/templates';
+    }
+
+    /**
+     * Initialize configuration
+     */
+    public function onShortcodeHandlers()
+    {
+        $this->grav['shortcode']->registerAllShortcodes(__DIR__.'/shortcodes');
     }
 }

--- a/markdown-rubytext.php
+++ b/markdown-rubytext.php
@@ -2,6 +2,7 @@
 namespace Grav\Plugin;
 
 use \Grav\Common\Plugin;
+use RocketTheme\Toolbox\Event\Event;
 
 
 class MarkdownRubyTextPlugin extends Plugin
@@ -14,6 +15,7 @@ class MarkdownRubyTextPlugin extends Plugin
         return [
             'onShortcodeHandlers' => ['onShortcodeHandlers', 0],
             'onTwigTemplatePaths' => ['onTwigTemplatePaths', 0],
+            'onMarkdownInitialized' => ['onMarkdownInitialized', 0],
         ];
     }
 
@@ -31,5 +33,47 @@ class MarkdownRubyTextPlugin extends Plugin
     public function onShortcodeHandlers()
     {
         $this->grav['shortcode']->registerAllShortcodes(__DIR__.'/shortcodes');
+    }
+
+    /**
+     * old implementation without shortcode
+     */
+    public function onMarkdownInitialized(Event $event)
+    {
+        $markdown = $event['markdown'];
+        // Initialize Text example
+        $markdown->addInlineType('{', 'RubyText');
+        // Add function to handle this
+        $markdown->inlineRubyText = function($excerpt) {
+            if (preg_match('/\{r}([^\s{]+){\/r:([^\s}]+)}/', $excerpt['text'], $matches))
+            {
+                return
+                array(
+                  'extent' => strlen($matches[0]),
+                  'element' => array(
+                    'name' => 'ruby',
+                    'handler' => 'elements',
+                    'text' => array(
+                        array(
+                            'name' => 'rb',
+                            'text' => $matches[1],
+                            ),
+                        array(
+                            'name' => 'rp',
+                            'text' => '（',
+                            ),
+                        array(
+                            'name' => 'rt',
+                            'text' => $matches[2],
+                            ),
+                        array(
+                            'name' => 'rp',
+                            'text' => '）',
+                            )
+                        )
+                    )
+                );
+            }
+        };
     }
 }

--- a/shortcodes/RubyShortcode.php
+++ b/shortcodes/RubyShortcode.php
@@ -1,0 +1,20 @@
+<?php
+namespace Grav\Plugin\Shortcodes;
+
+use Thunder\Shortcode\Shortcode\ShortcodeInterface;
+
+class RubyShortcode extends Shortcode
+{
+    public function init()
+    {
+        $this->shortcode->getHandlers()->add('ruby', function(ShortcodeInterface $sc) {
+            $output = $this->twig->processTemplate('partials/ruby.html.twig', [
+                'rt' => $sc->getParameter('ruby', $sc->getBbCode()) ?: '',
+                'rb' => $sc->getContent()
+            ]);
+
+            return $output;
+        });
+    }
+}
+?>

--- a/templates/partials/ruby.html.twig
+++ b/templates/partials/ruby.html.twig
@@ -1,0 +1,1 @@
+<ruby><rb>{{ rb }}</rb><rp>（</rp><rt>{{ rt }}</rt><rp>）</rp></ruby>


### PR DESCRIPTION
Use the Shortcode Core Plugin to provide the [ruby] shortcode. The input of `[ruby=かんじ]漢字[/ruby]` produces `<ruby><rb>漢字</rb><rp>（</rp><rt>かんじ</rt><rp>）</rp></ruby>`.

Second commit: restored the old implementation so pages using `{r}漢字{/r:かんじ}` don't break.